### PR TITLE
Drop support Node.js v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ workflows:
   version: 2
   node-multi-build:
     jobs:
-      - node-v4
       - node-v6
       - node-v8
       - node-latest
@@ -29,10 +28,6 @@ jobs:
       - run: npm test
       - run: bash <(curl -s https://codecov.io/bash)
 
-  node-v4:
-    <<: *base
-    docker:
-      - image: node:4
   node-v6:
     <<: *base
     docker:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm i iddfs
 
 ### Requirement
 - Node.js
-  - 4+
+  - 6+
 - Browser support
   - TODO
 


### PR DESCRIPTION
Node.js v4 reach EOL.
We should drop support unsupported version.